### PR TITLE
fix(dns): singbox ECS 分支补齐判空,修复 client_subnet 空值导致启动 FATAL

### DIFF
--- a/scripts/starts/clash_modify.sh
+++ b/scripts/starts/clash_modify.sh
@@ -21,7 +21,7 @@ prepare_clash_base_config() {
             if [ -n "$ecs_address" ];then
                 dns_fallback=$(echo "$dns_fallback, " | sed "s|, |#ecs-override=true\&ecs=$ecs_address, |g" | sed 's|, $||')
             else
-                logger "自动获取ecs网段失败！"
+                logger "自动获取ecs网段失败！" 33
             fi
         }
     }

--- a/scripts/starts/singbox_modify.sh
+++ b/scripts/starts/singbox_modify.sh
@@ -112,7 +112,11 @@ prepare_dns_config() {
     #ecs优化
     [ "$ecs_subnet" = ON ] && {
         . "$CRASHDIR"/libs/get_ecsip.sh
-        client_subnet='"client_subnet": "'"$ecs_address"'",'
+        if [ -n "$ecs_address" ]; then
+            client_subnet='"client_subnet": "'"$ecs_address"'",'
+        else
+            logger "自动获取ecs网段失败！" 33
+        fi
     }
     #根据dns模式生成
     [ "$dns_mod" = "redir_host" ] && {


### PR DESCRIPTION
## 问题

将 DNS 模式切换到 MIX（或任意模式）启动 sing-box 内核时，报：

```
FATAL[0000] decode config at /tmp/ShellCrash/jsons/dns.json: dns.client_subnet: netip.ParsePrefix(""): no '/'
```

mihomo 内核无此问题，仅 sing-box（singboxr）受影响。

## 根因

`ecs_subnet=ON` 时，`singbox_modify.sh` 通过 `get_ecsip.sh` 获取公网 IP 拼成 `client_subnet`。但获取流程在部分环境下会失败返回空：

1. **本地分支必然失败**：`get_ecsip.sh` 用 `grep -A1 "^# Interface wan$"` 匹配 resolv.conf，该标记是 OpenWrt 专属，梅林等系统的 `/tmp/resolv.conf` 没有此标记
2. **外网探测不稳定**：`members.3322.org` 是免费 DDNS 服务，有严格限流，频繁返回 `429 Too Many Requests` 甚至 `Empty reply`；`4.ipw.cn` 在部分运营商 DNS 下解析失败
3. **无响应校验**：`web_get_lite` 不校验 HTTP 状态码与响应内容，拿到 429 的 HTML body 也判为非空 `return`，后续更可靠的 `ipinfo.io` 不会尝试

失败后 `ecs_address=""`，`singbox_modify.sh` 仍写入 `"client_subnet": ""` → sing-box `netip.ParsePrefix("")` 报 `no '/'` FATAL。

而 `clash_modify.sh`（mihomo 分支）已有判空保护，空值时不写字段，仅静默写日志文件——所以 mihomo 不受影响。

## 修复

- **`scripts/starts/singbox_modify.sh`**：与 mihomo 分支对齐，加判空，失败时不写 `client_subnet` 字段并告警
- **`scripts/starts/clash_modify.sh`**：原 `logger` 未传颜色码，只写日志文件不打印终端，用户无感知。补颜色码 `33`（黄色），使告警同样打印到终端

## 验证

真机（华硕 TUF AX5400 / 梅林 / singboxr）实测：
- 修复前：`client_subnet: ""` → sing-box FATAL
- 修复后：成功时正常写入（如 `111.18.34.0/24`）；失败时字段不写入，sing-box 不再 FATAL，终端可见黄色告警